### PR TITLE
Implement divide money expressions

### DIFF
--- a/Funcky.Money.SourceGenerator/Iso4217RecordGenerator.cs
+++ b/Funcky.Money.SourceGenerator/Iso4217RecordGenerator.cs
@@ -158,11 +158,11 @@ public sealed class Iso4217RecordGenerator : IIncrementalGenerator
 
     private static Option<int> NumericCurrencyCode(XmlNode node)
         => GetInnerText(node, NumericCurrencyCodeNode)
-            .AndThen(ParseExtensions.ParseInt32OrNone);
+            .SelectMany(ParseExtensions.ParseInt32OrNone);
 
     private static int MinorUnit(XmlNode node)
         => GetInnerText(node, MinorUnitNode)
-            .AndThen(ParseExtensions.ParseInt32OrNone)
+            .SelectMany(ParseExtensions.ParseInt32OrNone)
             .GetOrElse(0);
 
     private static Option<string> GetInnerText(XmlNode node, string nodeName)

--- a/Funcky.Money.SourceGenerator/Iso4217RecordGenerator.cs
+++ b/Funcky.Money.SourceGenerator/Iso4217RecordGenerator.cs
@@ -158,18 +158,15 @@ public sealed class Iso4217RecordGenerator : IIncrementalGenerator
 
     private static Option<int> NumericCurrencyCode(XmlNode node)
         => GetInnerText(node, NumericCurrencyCodeNode)
-            .AndThen(ToInt);
+            .AndThen(ParseExtensions.ParseInt32OrNone);
 
     private static int MinorUnit(XmlNode node)
         => GetInnerText(node, MinorUnitNode)
-            .AndThen(ToInt)
+            .AndThen(ParseExtensions.ParseInt32OrNone)
             .GetOrElse(0);
 
     private static Option<string> GetInnerText(XmlNode node, string nodeName)
         => Option
             .FromNullable(node.SelectSingleNode(nodeName))
             .AndThen(n => n.InnerText);
-
-    private static Option<int> ToInt(string s)
-        => s.ParseInt32OrNone();
 }

--- a/Funcky.Money.Test/MoneyTest.cs
+++ b/Funcky.Money.Test/MoneyTest.cs
@@ -303,7 +303,7 @@ public sealed class MoneyTest
     }
 
     [Fact]
-    public void EvaluationOnZeroMoniesWorks()
+    public void EvaluationOnZeroMoneysWorks()
     {
         var sum = (Money.Zero + Money.Zero) * 1.5m;
 

--- a/Funcky.Money.Test/MoneyTest.cs
+++ b/Funcky.Money.Test/MoneyTest.cs
@@ -38,7 +38,7 @@ public sealed class MoneyTest
     }
 
     [Fact]
-    public void WeCanBuildTheSumOfTwoMoneysWithDifferentCurrenciesButOnEvaluationYouNeedAnEvaluationContext()
+    public void WeCanBuildTheSumOfTwoMoneysWithDifferentCurrenciesButOnEvaluationYouNeedAnEvaluationContextWithDefinedExchangeRates()
     {
         var fiveFrancs = new Money(5, Currency.CHF);
         var tenDollars = new Money(10, Currency.USD);
@@ -46,6 +46,7 @@ public sealed class MoneyTest
         var sum = fiveFrancs.Add(tenDollars);
 
         Assert.Throws<MissingEvaluationContextException>(() => sum.Evaluate());
+        Assert.Throws<MissingExchangeRateException>(() => sum.Evaluate(SwissRounding));
     }
 
     [Property]
@@ -470,6 +471,26 @@ public sealed class MoneyTest
         Assert.Throws<InvalidPrecisionException>(() => _ = RoundingStrategy.Default(0.0m));
         Assert.Throws<InvalidPrecisionException>(() => _ = RoundingStrategy.BankersRounding(0.0m));
         Assert.Throws<InvalidPrecisionException>(() => _ = RoundingStrategy.RoundWithAwayFromZero(0.0m));
+    }
+
+    [Fact]
+    public void WeCanCalculateADimensionlessFactorByDividingAMoneyByAnother()
+    {
+        Assert.Equal(2.5m, Money.CHF(5) / Money.CHF(2));
+        Assert.Equal(0.75m, Money.USD(3).Divide(Money.USD(4)));
+    }
+
+    [Fact]
+    public void DividingTwoMoneysOnlyWorksIfTheyAreOfTheSameCurrency()
+    {
+        Assert.ThrowsAny<MissingExchangeRateException>(() => Money.CHF(5) / Money.USD(2));
+    }
+
+    [Fact]
+    public void DividingTwoMoneysOnlyWorksIfTheDivisorIsNonZero()
+    {
+        Assert.Throws<DivideByZeroException>(() => Money.CHF(5) / Money.Zero);
+        Assert.Throws<DivideByZeroException>(() => Money.USD(3).Divide(Money.USD(0)));
     }
 
     private static List<decimal> Distributed(SwissMoney someMoney, int numberOfParts)

--- a/Funcky.Money.Test/TemporaryCultureSwitch.cs
+++ b/Funcky.Money.Test/TemporaryCultureSwitch.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Globalization;
 
 namespace Funcky.Test;

--- a/Funcky.Money/Bank/DefaultBank.cs
+++ b/Funcky.Money/Bank/DefaultBank.cs
@@ -22,7 +22,7 @@ internal sealed class DefaultBank : IBank
     public decimal ExchangeRate(Currency source, Currency target)
         => ExchangeRates
             .GetValueOrNone(key: (source, target))
-            .GetOrElse(() => throw new MissingExchangeRateException($"No exchange rate for {source.AlphabeticCurrencyCode} => {target.AlphabeticCurrencyCode}"));
+            .GetOrElse(() => throw new MissingExchangeRateException($"No exchange rate for {source.AlphabeticCurrencyCode} => {target.AlphabeticCurrencyCode}."));
 
     internal DefaultBank AddExchangeRate(Currency source, Currency target, decimal sellRate)
         => new(ExchangeRates.Add((source, target), sellRate));

--- a/Funcky.Money/Bank/DefaultBank.cs
+++ b/Funcky.Money/Bank/DefaultBank.cs
@@ -22,7 +22,7 @@ internal sealed class DefaultBank : IBank
     public decimal ExchangeRate(Currency source, Currency target)
         => ExchangeRates
             .GetValueOrNone(key: (source, target))
-            .GetOrElse(() => throw new MissingExchangeRateException($"No exchange rate for {source} => {target}"));
+            .GetOrElse(() => throw new MissingExchangeRateException($"No exchange rate for {source.AlphabeticCurrencyCode} => {target.AlphabeticCurrencyCode}"));
 
     internal DefaultBank AddExchangeRate(Currency source, Currency target, decimal sellRate)
         => new(ExchangeRates.Add((source, target), sellRate));

--- a/Funcky.Money/Bank/DefaultBank.cs
+++ b/Funcky.Money/Bank/DefaultBank.cs
@@ -22,7 +22,7 @@ internal sealed class DefaultBank : IBank
     public decimal ExchangeRate(Currency source, Currency target)
         => ExchangeRates
             .GetValueOrNone(key: (source, target))
-            .GetOrElse(() => throw new NotSupportedException($"No exchange rate for {source} => {target}"));
+            .GetOrElse(() => throw new MissingExchangeRateException($"No exchange rate for {source} => {target}"));
 
     internal DefaultBank AddExchangeRate(Currency source, Currency target, decimal sellRate)
         => new(ExchangeRates.Add((source, target), sellRate));

--- a/Funcky.Money/Exceptions/MissingExchangeRateException.cs
+++ b/Funcky.Money/Exceptions/MissingExchangeRateException.cs
@@ -5,7 +5,7 @@ namespace Funcky;
 public class MissingExchangeRateException : Exception
 {
     public MissingExchangeRateException()
-        : base("if you calculate with more than one currency, you have to define the exchange rate and target in the evaluation context.")
+        : base("If you calculate with more than one currency, you have to define the exchange rate and target in the evaluation context.")
     {
     }
 

--- a/Funcky.Money/Exceptions/MissingExchangeRateException.cs
+++ b/Funcky.Money/Exceptions/MissingExchangeRateException.cs
@@ -1,0 +1,26 @@
+using System.Runtime.Serialization;
+
+namespace Funcky;
+
+public class MissingExchangeRateException : Exception
+{
+    public MissingExchangeRateException()
+        : base("if you calculate with more than one currency, you have to define the exchange rate and target in the evaluation context.")
+    {
+    }
+
+    public MissingExchangeRateException(string? message)
+        : base(message)
+    {
+    }
+
+    public MissingExchangeRateException(string? message, Exception? innerException)
+        : base(message, innerException)
+    {
+    }
+
+    protected MissingExchangeRateException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
+    {
+    }
+}

--- a/Funcky.Money/ExpressionNodes/IMoneyExpression.cs
+++ b/Funcky.Money/ExpressionNodes/IMoneyExpression.cs
@@ -12,6 +12,9 @@ public interface IMoneyExpression
     public static IMoneyExpression operator /(IMoneyExpression dividend, decimal divisor)
         => dividend.Divide(divisor);
 
+    public static decimal operator /(IMoneyExpression dividend, IMoneyExpression divisor)
+        => dividend.Divide(divisor);
+
     public static IMoneyExpression operator +(IMoneyExpression augend, IMoneyExpression addend)
         => augend.Add(addend);
 

--- a/Funcky.Money/Extensions/MoneyDivisionExtension.cs
+++ b/Funcky.Money/Extensions/MoneyDivisionExtension.cs
@@ -4,4 +4,9 @@ public static class MoneyDivisionExtension
 {
     public static IMoneyExpression Divide(this IMoneyExpression dividend, decimal divisor)
         => new MoneyProduct(dividend, 1.0m / divisor);
+
+    public static decimal Divide(this IMoneyExpression dividend, IMoneyExpression divisor)
+    {
+        return 0m;
+    }
 }

--- a/Funcky.Money/Extensions/MoneyDivisionExtension.cs
+++ b/Funcky.Money/Extensions/MoneyDivisionExtension.cs
@@ -1,3 +1,5 @@
+using Funcky.Monads;
+
 namespace Funcky;
 
 public static class MoneyDivisionExtension
@@ -5,8 +7,13 @@ public static class MoneyDivisionExtension
     public static IMoneyExpression Divide(this IMoneyExpression dividend, decimal divisor)
         => new MoneyProduct(dividend, 1.0m / divisor);
 
-    public static decimal Divide(this IMoneyExpression dividend, IMoneyExpression divisor)
-    {
-        return 0m;
-    }
+    public static decimal Divide(this IMoneyExpression dividend, IMoneyExpression divisor, Option<MoneyEvaluationContext> context = default)
+        => Divide(
+            dividend.Evaluate(context),
+            divisor.Evaluate(context));
+
+    private static decimal Divide(Money dividend, Money divisor)
+        => dividend.Currency == divisor.Currency
+            ? dividend.Amount / divisor.Amount
+            : throw new MissingExchangeRateException();
 }

--- a/Funcky.Money/Funcky.Money.csproj
+++ b/Funcky.Money/Funcky.Money.csproj
@@ -6,7 +6,7 @@
         <Description>Funcky.Money is based on Kent Beck's TDD exercise but with more features.</Description>
         <PackageTags>Functional Money</PackageTags>
         <IsPackable>true</IsPackable>
-        <Version>1.1.0</Version>
+        <Version>1.2.0</Version>
     </PropertyGroup>
     <ItemGroup>
         <InternalsVisibleTo Include="$(AssemblyName).Test" />

--- a/Funcky.Money/Money.cs
+++ b/Funcky.Money/Money.cs
@@ -60,6 +60,9 @@ public sealed partial record Money : IMoneyExpression
     public static IMoneyExpression operator /(Money dividend, decimal divisor)
         => dividend.Divide(divisor);
 
+    public static decimal operator /(Money dividend, IMoneyExpression divisor)
+        => dividend.Divide(divisor);
+
     private static Currency SelectCurrency(Option<Currency> currency)
         => currency.GetOrElse(CurrencyCulture.CurrentCurrency);
 

--- a/Funcky.Money/MoneyEvaluationContext.cs
+++ b/Funcky.Money/MoneyEvaluationContext.cs
@@ -61,7 +61,7 @@ public sealed class MoneyEvaluationContext
 
         public MoneyEvaluationContext Build()
             => CompatibleRounding().Match(none: false, some: Not<bool>(Identity))
-                ? throw new IncompatibleRoundingException($"The roundingStrategy {_roundingStrategy} is incompatible with the smallest possible distribution unit {_distributionUnit}.")
+                ? throw new IncompatibleRoundingException($"The rounding strategy {_roundingStrategy} is incompatible with the smallest possible distribution unit {_distributionUnit}.")
                 : CreateContext();
 
         public Builder WithTargetCurrency(Currency currency)

--- a/Funcky.Money/MoneyEvaluationContext.cs
+++ b/Funcky.Money/MoneyEvaluationContext.cs
@@ -1,4 +1,5 @@
 using Funcky.Monads;
+using static Funcky.Functional;
 
 namespace Funcky;
 
@@ -8,8 +9,7 @@ public sealed class MoneyEvaluationContext
     {
         TargetCurrency = targetCurrency;
         DistributionUnit = distributionUnit;
-        RoundingStrategy = roundingStrategy
-            .GetOrElse(Funcky.RoundingStrategy.Default(distributionUnit.GetOrElse(Power.OfATenth(TargetCurrency.MinorUnitDigits))));
+        RoundingStrategy = roundingStrategy.GetOrElse(Funcky.RoundingStrategy.Default(distributionUnit.GetOrElse(Power.OfATenth(TargetCurrency.MinorUnitDigits))));
         Bank = bank;
     }
 
@@ -60,14 +60,9 @@ public sealed class MoneyEvaluationContext
         }
 
         public MoneyEvaluationContext Build()
-        {
-            if (CompatibleRounding().Match(none: false, some: Negate))
-            {
-                throw new IncompatibleRoundingException($"The roundingStrategy {_roundingStrategy} is incompatible with the smallest possible distribution unit {_distributionUnit}.");
-            }
-
-            return CreateContext();
-        }
+            => CompatibleRounding().Match(none: false, some: Not<bool>(Identity))
+                ? throw new IncompatibleRoundingException($"The roundingStrategy {_roundingStrategy} is incompatible with the smallest possible distribution unit {_distributionUnit}.")
+                : CreateContext();
 
         public Builder WithTargetCurrency(Currency currency)
             => With(targetCurrency: currency);
@@ -104,13 +99,9 @@ public sealed class MoneyEvaluationContext
 
         private MoneyEvaluationContext CreateContext()
             => new(
-                _targetCurrency.GetOrElse(()
-                    => throw new InvalidMoneyEvaluationContextBuilderException("Money evaluation context has no target currency set.")),
+                _targetCurrency.GetOrElse(() => throw new InvalidMoneyEvaluationContextBuilderException("Money evaluation context has no target currency set.")),
                 _distributionUnit,
                 _roundingStrategy,
                 _bank);
-
-        private bool Negate(bool c)
-            => !c;
     }
 }

--- a/README.md
+++ b/README.md
@@ -112,13 +112,14 @@ These is the evolving list of TDD requirements which led to the implementation.
 * [x] Money distribution has a precision member, use that instead of the contrived Precision on Rounding.
 * [x] Add unary and binary minus and the division operator.
 * [x] The context has a smallest distribution unit.
-
+* [ ] We can calculate c dimensionless factor by dividing two money objects.
 ### Decisions
 
 * We construct `Money` objects only from `decimal` and `int`. The decision how to handle external rounding problems should be done before construction of a `Money` object.
 * We keep Add, Multiply,etc because no all supported frameworks allow default implementations on the interface.
 * We prepare a distribution strategy but do not make it chosable at this point.
 * We support the following operators: unary + and -, and the binary operators ==, !=, +, -, * and /.
+* If you want to divide two different currencies you have to first Evaluate one to convert it to the other. Otherwise you will get a MissingExchangeRateException.
 
 ### Open Decisions
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ These is the evolving list of TDD requirements which led to the implementation.
 * We keep Add, Multiply,etc because no all supported frameworks allow default implementations on the interface.
 * We prepare a distribution strategy but do not make it chosable at this point.
 * We support the following operators: unary + and -, and the binary operators ==, !=, +, -, * and /.
-* You can divide to different currencies only with the `Divide(IMoneyExpression, IMoneyExpression, Option<MoneyEvaluationContext>)` method where you have to give a MoneyEvaluationContext with the necessary exchange rates.
+* You can divide two different currencies only with the `Divide(IMoneyExpression, IMoneyExpression, Option<MoneyEvaluationContext>)` method where you have to give a `MoneyEvaluationContext` with the necessary exchange rates.
 
 ### Open Decisions
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ These is the evolving list of TDD requirements which led to the implementation.
 * [x] Money distribution has a precision member, use that instead of the contrived Precision on Rounding.
 * [x] Add unary and binary minus and the division operator.
 * [x] The context has a smallest distribution unit.
-* [x] We can calculate a dimensionless factor by dividing two money objects.
+* [x] A dimensionless factor can be calculated by dividing two money objects.
 
 ### Decisions
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ These is the evolving list of TDD requirements which led to the implementation.
 * [x] Money distribution has a precision member, use that instead of the contrived Precision on Rounding.
 * [x] Add unary and binary minus and the division operator.
 * [x] The context has a smallest distribution unit.
-* [x] We can calculate c dimensionless factor by dividing two money objects.
+* [x] We can calculate a dimensionless factor by dividing two money objects.
 
 ### Decisions
 

--- a/README.md
+++ b/README.md
@@ -112,14 +112,15 @@ These is the evolving list of TDD requirements which led to the implementation.
 * [x] Money distribution has a precision member, use that instead of the contrived Precision on Rounding.
 * [x] Add unary and binary minus and the division operator.
 * [x] The context has a smallest distribution unit.
-* [ ] We can calculate c dimensionless factor by dividing two money objects.
+* [x] We can calculate c dimensionless factor by dividing two money objects.
+
 ### Decisions
 
 * We construct `Money` objects only from `decimal` and `int`. The decision how to handle external rounding problems should be done before construction of a `Money` object.
 * We keep Add, Multiply,etc because no all supported frameworks allow default implementations on the interface.
 * We prepare a distribution strategy but do not make it chosable at this point.
 * We support the following operators: unary + and -, and the binary operators ==, !=, +, -, * and /.
-* If you want to divide two different currencies you have to first Evaluate one to convert it to the other. Otherwise you will get a MissingExchangeRateException.
+* You can divide to different currencies only with the `Divide(IMoneyExpression, IMoneyExpression, Option<MoneyEvaluationContext>)` method where you have MoneyEvaluationContext who having the necessary exchange rates.
 
 ### Open Decisions
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ These is the evolving list of TDD requirements which led to the implementation.
 * We keep Add, Multiply,etc because no all supported frameworks allow default implementations on the interface.
 * We prepare a distribution strategy but do not make it chosable at this point.
 * We support the following operators: unary + and -, and the binary operators ==, !=, +, -, * and /.
-* You can divide to different currencies only with the `Divide(IMoneyExpression, IMoneyExpression, Option<MoneyEvaluationContext>)` method where you have MoneyEvaluationContext who having the necessary exchange rates.
+* You can divide to different currencies only with the `Divide(IMoneyExpression, IMoneyExpression, Option<MoneyEvaluationContext>)` method where you have to give a MoneyEvaluationContext with the necessary exchange rates.
 
 ### Open Decisions
 


### PR DESCRIPTION
This allows to calculate factors between two Money objects.
* The result is immediatly evaluated because we return a decimal.